### PR TITLE
Feature: add google fonts

### DIFF
--- a/src/app/notes/components/Note/index.styled.ts
+++ b/src/app/notes/components/Note/index.styled.ts
@@ -7,13 +7,13 @@ export const ListCard = styled.li`
 
   list-style: none;
   margin: 0;
-  border: 1px solid ${({ theme }) => theme.colors.gray};
+  border: 1px solid ${({ theme }) => theme.colors.secondary};
   border-radius: 10px;
   padding: 1rem;
   width: 100%;
   max-width: 65rem;
   background-color: ${({ theme }) => theme.colors.secondary};
-  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.5);
   transition: 0.3s ease-in-out;
 
   &:hover {

--- a/src/app/page.styled.ts
+++ b/src/app/page.styled.ts
@@ -5,23 +5,41 @@ export const Section = styled.section`
   justify-content: center;
   flex-direction: column;
   align-items: center;
-  gap: 4rem;
+  gap: 2rem;
 
   margin: 4rem 0;
 
+  h1 {
+    font-family: ${({ theme }) => theme.typography.fontFamily.slabo};
+    min-height: 11rem;
+    width: 100%;
+  }
+
   a {
-    color: ${({ theme }) => theme.colors.primary};
-    font-weight: bold;
-    font-size: ${({ theme }) => theme.fontSize.h4}rem;
-    border-bottom: 2px solid transparent;
-    transition: border-bottom 0.3s ease-in-out;
+    color: ${({ theme }) => theme.colors.secondary};
+    font-family: ${({ theme }) => theme.typography.fontFamily.ultra};
+    font-size: ${({ theme }) => theme.typography.fontSize.h5}rem;
+    border-bottom: 2.5px solid transparent;
+    background-color: ${({ theme }) => theme.colors.primary};
+    padding: 0.5rem 1rem;
+    border-radius: 10px;
+    transition: 0.4s ease-in-out;
 
     &:hover {
-      border-bottom: 2px solid ${({ theme }) => theme.colors.primary};
+      color: ${({ theme }) => theme.colors.primary};
+      background-color: ${({ theme }) => theme.colors.secondary};
+    }
+  }
+
+  @media screen and (min-width: ${({ theme }) => theme.breakpoints.sm}px) {
+    h1 {
+      min-height: 0;
     }
   }
 
   @media only screen and (min-width: ${({ theme }) => theme.breakpoints.lg}px) {
+    gap: 4rem;
+
     p {
       max-width: 50%;
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import * as Styled from './page.styled';
 
 const Home = () => (
   <Styled.Section>
-    <Typography tag="h1">
+    <Typography tag="h1" textalign="center">
       <Typewriter
         options={{
           strings: ['Time to get organised!'],

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import Typewriter from 'typewriter-effect';
@@ -26,6 +27,7 @@ const Home = () => (
       width={400}
       height={400}
       priority
+      rel="preload"
       alt="Man hugging a giant cup of spilling coffee"
     />
 

--- a/src/app/preload-resources.tsx
+++ b/src/app/preload-resources.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { Metadata } from 'next';
+import Script from 'next/script';
 
 export const metadataContent: Metadata = {
   title: {
@@ -35,10 +36,5 @@ export const metadataContent: Metadata = {
 
 // Below are metadata types the do not currently have built-in support (as of Next "14.0.4"). However, they can still be rendered in the layout or page itself ✌🏾
 export const PreloadResources: FC = () => (
-  <script
-    src="https://kit.fontawesome.com/89f72e9d16.js"
-    crossOrigin="anonymous"
-    rel="preload"
-    async
-  ></script>
+  <Script src="https://kit.fontawesome.com/89f72e9d16.js"></Script>
 );

--- a/src/components/Nav/index.styled.ts
+++ b/src/components/Nav/index.styled.ts
@@ -9,7 +9,8 @@ export const Nav = styled.nav`
 
   h1 {
     margin-right: 2rem;
-    font-size: ${({ theme }) => theme.fontSize.h4}rem;
+    font-family: ${({ theme }) => theme.typography.fontFamily.ultra};
+    font-size: ${({ theme }) => theme.typography.fontSize.h4}rem;
   }
 
   ul {

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -9,7 +9,7 @@ import * as Styled from './index.styled';
 const Nav = () => (
   <header>
     <Styled.Nav>
-      <Typography tag="h1">
+      <Typography tag="h1" textalign="center">
         <Link href={'/'}>Procrasti-Not(e)</Link>
       </Typography>
 

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -10,8 +10,9 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: ${theme.typography.fontFamily.slabo};
   color: ${theme.colors.text};
+  background-color: ${theme.colors.secondary};
 }
 
 html {

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,6 +1,6 @@
-import { Slabo_27px as Slabo, Ultra } from 'next/font/google';
+import { Slabo_27px, Ultra } from 'next/font/google';
 
-export const slabo = Slabo({
+export const slabo = Slabo_27px({
   weight: '400',
   subsets: ['latin'],
   fallback: ['serif'],

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,15 @@
+import { Slabo_27px as Slabo, Ultra } from 'next/font/google';
+
+export const slabo = Slabo({
+  weight: '400',
+  subsets: ['latin'],
+  fallback: ['serif'],
+  display: 'swap',
+});
+
+export const ultra = Ultra({
+  weight: '400',
+  subsets: ['latin'],
+  fallback: ['serif'],
+  display: 'swap',
+});

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,2 +1,3 @@
+export * from './fonts';
 export { default as GlobalStyles } from './GlobalStyles';
 export { default as theme } from './theme';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,3 +1,5 @@
+import { slabo, ultra } from './fonts';
+
 const theme = {
   breakpoints: {
     sm: 576,
@@ -5,30 +7,31 @@ const theme = {
     lg: 992,
     xl: 1200,
   },
-  fontSize: {
-    body1: 1.8,
-    body2: 1.6,
-    h1: 4,
-    h2: 3.6,
-    h3: 2.8,
-    h4: 2.2,
-    h5: 1.8,
-    h6: 1.6,
+  typography: {
+    fontFamily: {
+      slabo: `${slabo.style.fontFamily}`,
+      ultra: `${ultra.style.fontFamily}`,
+    },
+    fontSize: {
+      body1: 1.8,
+      body2: 1.6,
+      h1: 4,
+      h2: 3.6,
+      h3: 2.8,
+      h4: 2.2,
+      h5: 1.8,
+      h6: 1.6,
+    },
   },
   colors: {
     primary: '#ff6161',
     secondary: '#fcfaf3',
     secondaryDark: '#39a2ae',
     tertiary: '#cbbaed',
-    background: '#fff',
+    tertiaryDark: '#8f6ed5',
     text: '#231f20',
     white: '#fff',
     black: '#000',
-    gray: '#ccc',
-    grayLight: '#f7f7f7',
-    grayDark: '#333',
-    grayDarker: '#222',
-    grayDarkest: '#111',
   },
 };
 

--- a/src/tests/vitest.setup.ts
+++ b/src/tests/vitest.setup.ts
@@ -1,2 +1,19 @@
+import { Slabo_27px, Ultra } from 'next/font/google';
+import { vi } from 'vitest';
+
 import '@testing-library/jest-dom/vitest';
 import 'vitest-canvas-mock';
+
+// Mock the next/font/google module
+vi.mock('next/font/google', () => ({
+  Ultra: () => ({
+    style: {
+      fontFamily: Ultra,
+    },
+  }),
+  Slabo_27px: () => ({
+    style: {
+      fontFamily: Slabo_27px,
+    },
+  }),
+}));


### PR DESCRIPTION
## 🚀 What I did

- add Google fonts with optimised `next/fonts` 
  - Slabo 27px
  - Ultra
- minor styling updates 💅🏽
- minor performance enhancement adjustments 📈

## Attachments... 👀
<img width="1728" alt="Screenshot 2023-12-24 at 22 05 46" src="https://github.com/tanaka-lusengo/procrasti-note/assets/79418686/503f9c83-b77a-434f-96b7-aa8570a15328">

<!--

Before merging, ensure the below points have been considered:

- All tests have passed ✅
- Project build status is: Ready ✅
- You've inserted additional images, files or ref links (if relevant).
- And of course, emojis are more than welcome! 😁

-->
